### PR TITLE
Fix 'Run DBS' section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here we run DBS with DenseNet-121 in 4 workers' distributed environment where wo
 Additionally, the total batchsize of the entire cluster is set to 512, other arguments remain default.
 
 ```
-python dbs.py -d false -ws 4 -b 512 -m densenet -gpu 0,0,0,1
+python dbs.py -d false -ws 4 -b 512 -m densenet -ds cifar10 -gpu 0,0,0,1
 ```
 
 Details of other arguments can be referred in `parser.py`


### PR DESCRIPTION
```
python dbs.py -d false -ws 4 -b 512 -m densenet -gpu 0,0,0,1
```
The original command in README.md raises the following error:
```
  File "~/Dynamic_Load_Balance_DistributedDNN/dbs.py", line 400, in run
    num_batches = math.ceil(len(train_set.dataset) / float(bsz))  # Calculate how many iterations in this epoch.
AttributeError: 'Tensor' object has no attribute 'dataset'
```

This is simply solved by configuring 'cifar10' (which is the benchmark dataset in the paper) to an argument 'ds'.
```
python dbs.py -d false -ws 4 -b 512 -m densenet -ds cifar10 -gpu 0,0,0,1
```
I think this default command will make users more convenient. :)

Best regards,
Gyeongchan Yun
